### PR TITLE
Fixed the OU parameter to join domains

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,8 +60,7 @@ class pbis (
   # Construct the domainjoin-cli options string
   # AssumeDefaultDomain and UserDomainPrefix are configured after joining
   if $ou {
-    $ou_path = transform_ou($ou)
-    $opt_ou = "--ou ${ou_path}"
+    $opt_ou = "--ou \"${ou}\""
   }
   else {
     $opt_ou = ''


### PR DESCRIPTION
_I'm sending you this pull request cause you have a fork that worked better than the original maintainer who does not seem to respond to pull requests anymore. Your changes fixed some good points._

Needed quotes to support spaces in OUs. Also, it was running this function to flip the OU and put slashes instead of comma which does not work so I took this out.
