### PR TITLE
Fixed issue with selectors using fail() function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@ class pbis (
   $ad_domain,
   $bind_username,
   $bind_password,
-  $ou                    = rpbis::params::ou,
+  $ou                    = $pbis::params::ou,
   $enabled_modules       = $pbis::params::enabled_modules,
   $disabled_modules      = $pbis::params::disabled_modules,
   $package               = $pbis::params::package,
@@ -52,6 +52,7 @@ class pbis (
     # Copy the pbis-open package to the node.
     file { "/opt/${package_file}":
       ensure  => file,
+      source  => "puppet:///modules/pbis/${package_file}",
       links   => "follow",
       require => File["/opt"],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,9 @@ class pbis (
   elsif $use_repository == false {
     # Otherwise, download and install the package from the puppetmaster...
     # a low-performance repo for the poor man
+    file { "/opt" :
+      ensure => "directory",
+    }
     file { "/opt/${package_file}":
       ensure => file,
       source => "puppet:///modules/pbis/${package_file}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,8 +34,9 @@ class pbis (
     # Otherwise, download and install the package from the puppetmaster...
     # a low-performance repo for the poor man
     file { "/opt/${package_file}":
-      ensure  => file,
-      source  => "puppet:///modules/pbis/${package_file}",
+      ensure => file,
+      source => "puppet:///modules/pbis/${package_file}",
+      links  => "follow",
     }
     package { $package:
       ensure   => installed,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class pbis::params {
   # package options
   $use_repository        = false
   $package               = 'pbis-open'
+  $upgrade_package       = 'pbis-open-upgrade'
   $service_name          = 'lsass'
 
   # domainjoin-cli options
@@ -31,20 +32,28 @@ class pbis::params {
   # When using Puppet's built-in fileserver, choose the .deb or .rpm 
   # automatically.
 
+  # Get the packaging Format
   case $::osfamily {
-     'Debian':        { $package_file = "${package}.${::architecture}.deb" }
-     'RedHat','Suse': { $package_file = "${package}.${::architecture}.rpm" }
-     default:         {
-       fail("Unsupported operating system: ${::operatingsystem}.")
-     }
-  }
-
-  case $::osfamily {
-    'Debian':        { $package_file_provider = 'dpkg' }
-    'RedHat','Suse': { $package_file_provider = 'rpm' }
+    'Debian':        { $package_format = "deb" }
+    'RedHat','Suse': { $package_format = "rpm" }
     default:         {
       fail("Unsupported operating system: ${::operatingsystem}.")
     }
+  }
+
+  # Build the file names.
+  $package_file =
+    "${package}.${::architecture}.${package_format}"
+  $upgrade_package_file =
+    "${upgrade_package}.${::architecture}.${package_format}"
+
+  # Set the package installation provider
+  case $::osfamily {
+   'Debian':        { $package_file_provider = 'dpkg' }
+   'RedHat','Suse': { $package_file_provider = 'rpm' }
+   default:         {
+     fail("Unsupported operating system: ${::operatingsystem}.")
+   }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,14 +12,14 @@ class pbis::params {
   $disabled_modules      = undef
 
   # PBIS configuration
-  $assume_default_domain = true
+  $assume_default_domain = false
   $create_home_dir       = true
   $domain_separator      = '\\'
-  $space_replacement     = '_'
+  $space_replacement     = '^'
   $home_dir_prefix       = '/home'
   $home_dir_umask        = '022'
-  $home_dir_template     = '%H/%D/%U'
-  $login_shell_template  = '/bin/bash'
+  $home_dir_template     = '%H/local/%D/%U'
+  $login_shell_template  = '/bin/sh'
   $require_membership_of = undef
   $skeleton_dirs         = '/etc/skel'
   $user_domain_prefix    = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,14 +30,21 @@ class pbis::params {
   # PBIS Open is packaged for Red Hat, Suse, and Debian derivatives.
   # When using Puppet's built-in fileserver, choose the .deb or .rpm 
   # automatically.
-  $package_file = $::osfamily ? {
-    'Debian'          => "${package}.${::architecture}.deb",
-    '/(RedHat|Suse)/' => "${package}.${::architecture}.rpm",
-    default           => fail("Unsupported operating system: ${::operatingsystem}."),
+
+  case $::osfamily {
+     'Debian':        { $package_file = "${package}.${::architecture}.deb" }
+     'RedHat','Suse': { $package_file = "${package}.${::architecture}.rpm" }
+     default:         {
+       fail("Unsupported operating system: ${::operatingsystem}.")
+     }
   }
-  $package_file_provider = $::osfamily ? {
-    'Debian'          => 'dpkg',
-    '/(RedHat|Suse)/' => 'rpm',
-    default           => fail("Unsupported operating system: ${::operatingsystem}."),
+
+  case $::osfamily {
+    'Debian':        { $package_file_provider = 'dpkg' }
+    'RedHat','Suse': { $package_file_provider = 'rpm' }
+    default:         {
+      fail("Unsupported operating system: ${::operatingsystem}.")
+    }
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,10 +32,16 @@ class pbis::params {
   # When using Puppet's built-in fileserver, choose the .deb or .rpm 
   # automatically.
 
-  # Get the packaging Format
+  # Get the packaging Format and Set the package installation provider
   case $::osfamily {
-    'Debian':        { $package_format = "deb" }
-    'RedHat','Suse': { $package_format = "rpm" }
+   'Debian':        { 
+      $package_file_provider = 'dpkg' 
+      $package_format = "deb" 
+    }
+    'RedHat','Suse': { 
+      $package_file_provider = 'rpm' 
+      $package_format = "rpm" 
+    }
     default:         {
       fail("Unsupported operating system: ${::operatingsystem}.")
     }
@@ -46,14 +52,4 @@ class pbis::params {
     "${package}.${::architecture}.${package_format}"
   $upgrade_package_file =
     "${upgrade_package}.${::architecture}.${package_format}"
-
-  # Set the package installation provider
-  case $::osfamily {
-   'Debian':        { $package_file_provider = 'dpkg' }
-   'RedHat','Suse': { $package_file_provider = 'rpm' }
-   default:         {
-     fail("Unsupported operating system: ${::operatingsystem}.")
-   }
-  }
-
 }


### PR DESCRIPTION
Per Puppet/PUP-1457 at https://tickets.puppetlabs.com/browse/PUP-1457, Puppet does not currently support the fail function inside of a selector. The attempted use errors out:
Error: Failed to compile catalog for node <nodename>: Function 'fail' does not return a value at /etc/puppet/environments/production/modules/pbis/manifests/params.pp:36 on node <nodename>
